### PR TITLE
Add an A-Tag for Mastodon verify

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,8 +4,8 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width" />
-		%sveltekit.head%
 		<a rel="me" href="https://troet.cafe/@CubyxNetwork"></a>
+		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
Fügt den Mastodon Verify A-Tag hinzu für die Troet.cafe Instanz: 
`<a rel="me" href="https://troet.cafe/@CubyxNetwork">Mastodon</a>`