### PR TITLE
change: Weiterleitung zu bio.link als (vorläufiges) Kontaktformular

### DIFF
--- a/src/components/Footer/FooterLegal.svelte
+++ b/src/components/Footer/FooterLegal.svelte
@@ -5,7 +5,7 @@
 	<p>•</p>
 	<a href="https://cubyx.eu/status" target="_blank">Statuspage</a>
 	<p>•</p>
-	<a href="/kontakt">Kontakt</a>
+	<a href="https://bio.link/cubyx">Kontakt</a>
 </div>
 
 <style>


### PR DESCRIPTION
Kontaktmöglichkeit wird auf [bio.link/cubyx](https://bio.link/cubyx) geboten, weshalb die Kontakt Seite entfällt und daraus eine Weiterleitung wurde.