### PR TITLE
feat: Ladebalken für Seitenwechsel hinzugefügt

### DIFF
--- a/src/components/Common/PageLoadingBar.svelte
+++ b/src/components/Common/PageLoadingBar.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { onDestroy, onMount } from 'svelte';
+	import { tweened } from 'svelte/motion';
+	import { cubicOut } from 'svelte/easing';
+	import { fade } from 'svelte/transition';
+
+	const progress = tweened(0, {
+		delay: 250,
+		duration: 5000,
+		easing: cubicOut
+	});
+
+	onMount(() => {
+		progress.set(0.95);
+	});
+
+	onDestroy(() => {});
+</script>
+
+<div class="fixed left-0 top-0 z-50 h-1 w-screen" in:fade={{ delay: 250 }} out:fade>
+	<div class="h-full w-[var(--width)] bg-primary" style={`--width: ${$progress * 100}%`} />
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,9 @@
-<script lang="ts">
+<script>
 	import '../app.css';
 	import Header from '../components/Header/Header.svelte';
 	import Footer from '../components/Footer/Footer.svelte';
+	import PageLoadingBar from '../components/Common/PageLoadingBar.svelte';
+	import { navigating } from '$app/stores';
 
 	let headerConfig = [
 		{ text: 'Home', link: '/' },
@@ -10,6 +12,10 @@
 		{ text: 'Discord', link: 'https://cubyx.eu/discord', external: true }
 	];
 </script>
+
+{#if $navigating}
+	<PageLoadingBar />
+{/if}
 
 <Header links={headerConfig} />
 


### PR DESCRIPTION
fixes #136 

Sollte der Wechsel einer Page mal zu lange dauern, so wird eine kleine grüne Leiste am oberen Bildschirmrand angezeigt, welche den User signalisieren soll, dass sich noch etwas tut.

> [!WARNING]
> Es handelt sich um keine echte Ladeleiste, sondern nur um eine Attrappe.